### PR TITLE
Use NuGet package for StartPage.SDK

### DIFF
--- a/source/QuickSearch.csproj
+++ b/source/QuickSearch.csproj
@@ -102,7 +102,7 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="StartPage.SDK">
-      <HintPath>..\..\StartPage-for-Playnite\source\StartPage.SDK\bin\Release\StartPage.SDK.dll</HintPath>
+      <HintPath>..\..\StartPage-for-Playnite\source\StartPage.SDK\bin\$(Configuration)\net462\StartPage.SDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/source/QuickSearch.csproj
+++ b/source/QuickSearch.csproj
@@ -96,13 +96,13 @@
     <Reference Include="Octokit, Version=0.50.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\Octokit.0.50.0\lib\net46\Octokit.dll</HintPath>
     </Reference>
-    <Reference Include="Playnite.SDK, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\PlayniteSDK.6.0.0\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK, Version=6.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\PlayniteSDK.6.1.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="StartPage.SDK">
-      <HintPath>..\..\StartPage-for-Playnite\source\StartPage.SDK\bin\$(Configuration)\net462\StartPage.SDK.dll</HintPath>
+    <Reference Include="StartPage.SDK, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\StartPage.SDK.1.0.0\lib\net462\StartPage.SDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/source/QuickSearchSDK/QuickSearchSDK.csproj
+++ b/source/QuickSearchSDK/QuickSearchSDK.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\Search\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Playnite.SDK, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PlayniteSDK.6.0.0-preview4\lib\net462\Playnite.SDK.dll</HintPath>

--- a/source/packages.config
+++ b/source/packages.config
@@ -11,7 +11,8 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net462" />
   <package id="Newtonsoft.Json.Schema" version="3.0.5" targetFramework="net462" />
   <package id="Octokit" version="0.50.0" targetFramework="net462" />
-  <package id="PlayniteSDK" version="6.0.0" targetFramework="net462" />
+  <package id="PlayniteSDK" version="6.1.0" targetFramework="net462" />
   <package id="SharpZipLib" version="1.3.3" targetFramework="net462" />
+  <package id="StartPage.SDK" version="1.0.0" targetFramework="net462" />
   <package id="YamlDotNet" version="5.4.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
I created a second pull request for the change to NuGet package because I don't know if you prefer to keep the local reference for StartPage.SDK or use the NuGet reference.

This pull request incorporates the fix of the Newtonsoft.Json reference too.